### PR TITLE
Extract shared order filtering logic into custom hook

### DIFF
--- a/apps/web/src/app/user/my-claims/page.tsx
+++ b/apps/web/src/app/user/my-claims/page.tsx
@@ -11,7 +11,7 @@ import { useEffect, useState } from "react";
 import OrderListItem from "~/app/_components/features/OrderListItem";
 import OrderListPriceItem from "~/app/_components/features/OrderListPriceItem";
 import { ProfileOptionLayout } from "~/app/_components/features/ProfileOptionLayout";
-import { DeliveryMethod, SalesStatusType } from "~/types";
+import { DeliveryMethod, SalesStatus } from "~/types";
 
 const mockedOrders = [
 	{
@@ -21,7 +21,7 @@ const mockedOrders = [
 				id: "1",
 				productName: "productName",
 				buyerName: "buyer1_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 				delivery: DeliveryMethod.Address,
 				price: 30,
 				claimed: false,
@@ -30,7 +30,7 @@ const mockedOrders = [
 				id: "2",
 				productName: "productName2",
 				buyerName: "buyer2_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 				delivery: DeliveryMethod.Meetup,
 				price: 30,
 				claimed: false,
@@ -44,7 +44,7 @@ const mockedOrders = [
 				id: "3",
 				productName: "productName3",
 				buyerName: "buyer1_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 				delivery: DeliveryMethod.Address,
 				price: 30,
 				claimed: true,
@@ -53,7 +53,7 @@ const mockedOrders = [
 				id: "4",
 				productName: "productName4",
 				buyerName: "buyer2_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 				delivery: DeliveryMethod.Meetup,
 				price: 30,
 				claimed: true,

--- a/apps/web/src/app/user/my-orders/page.tsx
+++ b/apps/web/src/app/user/my-orders/page.tsx
@@ -5,12 +5,12 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import Button from "@repo/ui/button";
 import CheckBox from "@repo/ui/form/checkBox";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import OrderListItem from "~/app/_components/features/OrderListItem";
 import { ProfileOptionLayout } from "~/app/_components/features/ProfileOptionLayout";
 import BottomModal from "~/app/_components/ui/BottomModal";
-import { type FormValues, SalesStatusType, filtersSchema } from "~/types";
+import { useOrderFiltering } from "~/hooks/user/useOrderFiltering";
+import { type FormValues, SalesStatus, filtersSchema } from "~/types";
 
 const mockedOrders = [
 	{
@@ -20,13 +20,13 @@ const mockedOrders = [
 				id: "1",
 				productName: "Edit profile",
 				sellerName: "seller1_fullname",
-				status: SalesStatusType.Paid,
+				status: SalesStatus.Paid,
 			},
 			{
 				id: "2",
 				productName: "My Orders",
 				sellerName: "seller2_fullname",
-				status: SalesStatusType.Paid,
+				status: SalesStatus.Paid,
 			},
 		],
 	},
@@ -37,91 +37,49 @@ const mockedOrders = [
 				id: "3",
 				productName: "productName",
 				sellerName: "seller1_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 			},
 			{
 				id: "4",
 				productName: "productName",
 				sellerName: "seller2_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 			},
 		],
 	},
 ];
 
+const filtersDefaults = {
+	statusPaid: false,
+	statusPrepared: false,
+	statusShipped: false,
+	statusDelivered: false,
+};
+
 export default function MyOrders() {
-	const [searchTerm, setSearchTerm] = useState("");
-	const [isFiltersModalOpen, setIsFiltersModalOpen] = useState(false);
-	const [filteredOrders, setFilteredOrders] = useState(mockedOrders);
-	const [activeFilters, setActiveFilters] = useState<FormValues>({});
+	const {
+		searchTerm,
+		setSearchTerm,
+		isFiltersModalOpen,
+		openFiltersModal,
+		closeFiltersModal,
+		filteredOrders,
+		applyFilters,
+	} = useOrderFiltering({
+		orders: mockedOrders,
+		searchKey: "sellerName",
+		filters: filtersDefaults,
+	});
 	const router = useRouter();
-
-	const openFiltersModal = () => {
-		setIsFiltersModalOpen(true);
-	};
-
-	const closeFiltersModal = () => {
-		setIsFiltersModalOpen(false);
-	};
 
 	const { control, handleSubmit } = useForm<FormValues>({
 		resolver: zodResolver(filtersSchema),
-		defaultValues: {
-			statusPaid: false,
-			statusPrepared: false,
-			statusShipped: false,
-			statusDelivered: false,
-		},
+		defaultValues: filtersDefaults,
 	});
-
-	const onSubmit = (data: FormValues) => {
-		console.log(data);
-		setActiveFilters(data);
-		closeFiltersModal();
-	};
 
 	const handleItemClick = (id: string) => {
 		router.push(`/user/my-orders/${id}`);
 	};
-
-	useEffect(() => {
-		const newFilteredOrders = mockedOrders
-			.map((orderGroup) => ({
-				...orderGroup,
-				items: orderGroup.items.filter((item) => {
-					const matchesSearch = searchTerm
-						? item.sellerName.toLowerCase().includes(searchTerm.toLowerCase())
-						: true;
-
-					const activeStatusFilters = [
-						activeFilters.statusPaid,
-						activeFilters.statusPrepared,
-						activeFilters.statusShipped,
-						activeFilters.statusDelivered,
-					];
-
-					const matchesStatus = activeStatusFilters.some(Boolean)
-						? (activeFilters.statusPaid &&
-								item.status === SalesStatusType.Paid) ??
-							(activeFilters.statusPrepared &&
-								item.status === SalesStatusType.Prepared) ??
-							(activeFilters.statusShipped &&
-								item.status === SalesStatusType.Shipped) ??
-							(activeFilters.statusDelivered &&
-								item.status === SalesStatusType.Delivered)
-						: true;
-
-					return matchesSearch && matchesStatus;
-				}),
-			}))
-			.filter((orderGroup) => orderGroup.items.length > 0);
-
-		if (!searchTerm && !Object.values(activeFilters).some(Boolean)) {
-			setFilteredOrders(mockedOrders);
-		} else {
-			setFilteredOrders(newFilteredOrders);
-		}
-	}, [searchTerm, activeFilters]);
 
 	return (
 		<ProfileOptionLayout title="My orders">
@@ -157,7 +115,7 @@ export default function MyOrders() {
 									<OrderListItem
 										key={`${order.productName}-${orderIndex}`}
 										productName={order.productName}
-										name={order.sellerName}
+										name={order.sellerName ?? "unknown_seller"}
 										status={order.status}
 										onClick={() => handleItemClick(order.id)}
 									/>
@@ -172,33 +130,33 @@ export default function MyOrders() {
 			</div>
 
 			<BottomModal isOpen={isFiltersModalOpen} onClose={closeFiltersModal}>
-				<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+				<form onSubmit={handleSubmit(applyFilters)} className="space-y-4">
 					<h3 className="text-xl font-semibold my-4 text-content-title">
 						Status
 					</h3>
 					<div className="flex flex-col gap-2">
 						<>
 							<CheckBox
-								name={`status${SalesStatusType.Paid}`}
-								label={SalesStatusType.Paid}
+								name={`status${SalesStatus.Paid}`}
+								label={SalesStatus.Paid}
 								control={control}
 							/>
 							<hr className="my-2 border-surface-primary-soft" />
 							<CheckBox
-								name={`status${SalesStatusType.Prepared}`}
-								label={SalesStatusType.Prepared}
+								name={`status${SalesStatus.Prepared}`}
+								label={SalesStatus.Prepared}
 								control={control}
 							/>
 							<hr className="my-2 border-surface-primary-soft" />
 							<CheckBox
-								name={`status${SalesStatusType.Shipped}`}
-								label={SalesStatusType.Shipped}
+								name={`status${SalesStatus.Shipped}`}
+								label={SalesStatus.Shipped}
 								control={control}
 							/>
 							<hr className="my-2 border-surface-primary-soft" />
 							<CheckBox
-								name={`status${SalesStatusType.Delivered}`}
-								label={SalesStatusType.Delivered}
+								name={`status${SalesStatus.Delivered}`}
+								label={SalesStatus.Delivered}
 								control={control}
 							/>
 						</>

--- a/apps/web/src/app/user/my-sales/page.tsx
+++ b/apps/web/src/app/user/my-sales/page.tsx
@@ -5,16 +5,15 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import Button from "@repo/ui/button";
 import CheckBox from "@repo/ui/form/checkBox";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
-import { z } from "zod";
 import OrderListItem from "~/app/_components/features/OrderListItem";
 import { ProfileOptionLayout } from "~/app/_components/features/ProfileOptionLayout";
 import BottomModal from "~/app/_components/ui/BottomModal";
+import { useOrderFiltering } from "~/hooks/user/useOrderFiltering";
 import {
 	DeliveryMethod,
 	type FormValues,
-	SalesStatusType,
+	SalesStatus,
 	filtersSchema,
 } from "~/types";
 
@@ -26,14 +25,14 @@ const mockedOrders = [
 				id: "1",
 				productName: "Edit profile",
 				buyerName: "buyer1_fullname",
-				status: SalesStatusType.Paid,
+				status: SalesStatus.Paid,
 				delivery: DeliveryMethod.Address,
 			},
 			{
 				id: "2",
 				productName: "My Orders",
 				buyerName: "buyer2_fullname",
-				status: SalesStatusType.Paid,
+				status: SalesStatus.Paid,
 				delivery: DeliveryMethod.Meetup,
 			},
 		],
@@ -45,107 +44,53 @@ const mockedOrders = [
 				id: "3",
 				productName: "productName",
 				buyerName: "buyer1_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 				delivery: DeliveryMethod.Address,
 			},
 			{
 				id: "4",
 				productName: "productName",
 				buyerName: "buyer2_fullname",
-				status: SalesStatusType.Delivered,
+				status: SalesStatus.Delivered,
 				delivery: DeliveryMethod.Meetup,
 			},
 		],
 	},
 ];
 
+const filtersDefaults = {
+	statusPaid: false,
+	statusPrepared: false,
+	statusShipped: false,
+	statusDelivered: false,
+	deliveryAddress: false,
+	deliveryMeetup: false,
+};
+
 export default function MySales() {
-	const [searchTerm, setSearchTerm] = useState("");
-	const [isFiltersModalOpen, setIsFiltersModalOpen] = useState(false);
-	const [filteredOrders, setFilteredOrders] = useState(mockedOrders);
-	const [activeFilters, setActiveFilters] = useState<FormValues>({});
+	const {
+		searchTerm,
+		setSearchTerm,
+		isFiltersModalOpen,
+		openFiltersModal,
+		closeFiltersModal,
+		filteredOrders,
+		applyFilters,
+	} = useOrderFiltering({
+		orders: mockedOrders,
+		searchKey: "buyerName",
+		filters: filtersDefaults,
+	});
 	const router = useRouter();
-
-	const openFiltersModal = () => {
-		setIsFiltersModalOpen(true);
-	};
-
-	const closeFiltersModal = () => {
-		setIsFiltersModalOpen(false);
-	};
 
 	const { control, handleSubmit } = useForm<FormValues>({
 		resolver: zodResolver(filtersSchema),
-		defaultValues: {
-			statusPaid: false,
-			statusPrepared: false,
-			statusShipped: false,
-			statusDelivered: false,
-			deliveryAddress: false,
-			deliveryMeetup: false,
-		},
+		defaultValues: filtersDefaults,
 	});
-
-	const onSubmit = (data: FormValues) => {
-		console.log(data);
-		setActiveFilters(data);
-		closeFiltersModal();
-	};
 
 	const handleItemClick = (id: string) => {
 		router.push(`/user/my-sales/${id}`);
 	};
-
-	useEffect(() => {
-		const newFilteredOrders = mockedOrders
-			.map((orderGroup) => ({
-				...orderGroup,
-				items: orderGroup.items.filter((item) => {
-					const matchesSearch = searchTerm
-						? item.buyerName.toLowerCase().includes(searchTerm.toLowerCase())
-						: true;
-
-					const activeStatusFilters = [
-						activeFilters.statusPaid,
-						activeFilters.statusPrepared,
-						activeFilters.statusShipped,
-						activeFilters.statusDelivered,
-					];
-
-					const matchesStatus = !activeStatusFilters.some(Boolean)
-						? true
-						: (activeFilters.statusPaid &&
-								item.status === SalesStatusType.Paid) ??
-							(activeFilters.statusPrepared &&
-								item.status === SalesStatusType.Prepared) ??
-							(activeFilters.statusShipped &&
-								item.status === SalesStatusType.Shipped) ??
-							(activeFilters.statusDelivered &&
-								item.status === SalesStatusType.Delivered);
-
-					const activeDeliveryFilters = [
-						activeFilters.deliveryAddress,
-						activeFilters.deliveryMeetup,
-					];
-
-					const matchesDelivery = !activeDeliveryFilters.some(Boolean)
-						? true
-						: (activeFilters.deliveryAddress &&
-								item.delivery === DeliveryMethod.Address) ??
-							(activeFilters.deliveryMeetup &&
-								item.delivery === DeliveryMethod.Meetup);
-
-					return matchesSearch && matchesStatus && matchesDelivery;
-				}),
-			}))
-			.filter((orderGroup) => orderGroup.items.length > 0);
-
-		if (!searchTerm && !Object.values(activeFilters).some(Boolean)) {
-			setFilteredOrders(mockedOrders);
-		} else {
-			setFilteredOrders(newFilteredOrders);
-		}
-	}, [searchTerm, activeFilters]);
 
 	return (
 		<ProfileOptionLayout title="My Sellers">
@@ -181,7 +126,7 @@ export default function MySales() {
 									<OrderListItem
 										key={`${order.productName}-${orderIndex}`}
 										productName={order.productName}
-										name={order.buyerName}
+										name={order.buyerName ?? "unknown_buyer"}
 										status={order.status}
 										onClick={() => handleItemClick(order.id)}
 									/>
@@ -196,7 +141,7 @@ export default function MySales() {
 			</div>
 
 			<BottomModal isOpen={isFiltersModalOpen} onClose={closeFiltersModal}>
-				<form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+				<form onSubmit={handleSubmit(applyFilters)} className="space-y-4">
 					<h3 className="text-xl font-semibold my-4 text-content-title">
 						Delivery method
 					</h3>
@@ -221,26 +166,26 @@ export default function MySales() {
 					<div className="flex flex-col gap-2">
 						<>
 							<CheckBox
-								name={`status${SalesStatusType.Paid}`}
-								label={SalesStatusType.Paid}
+								name={`status${SalesStatus.Paid}`}
+								label={SalesStatus.Paid}
 								control={control}
 							/>
 							<hr className="my-2 border-surface-primary-soft" />
 							<CheckBox
-								name={`status${SalesStatusType.Prepared}`}
-								label={SalesStatusType.Prepared}
+								name={`status${SalesStatus.Prepared}`}
+								label={SalesStatus.Prepared}
 								control={control}
 							/>
 							<hr className="my-2 border-surface-primary-soft" />
 							<CheckBox
-								name={`status${SalesStatusType.Shipped}`}
-								label={SalesStatusType.Shipped}
+								name={`status${SalesStatus.Shipped}`}
+								label={SalesStatus.Shipped}
 								control={control}
 							/>
 							<hr className="my-2 border-surface-primary-soft" />
 							<CheckBox
-								name={`status${SalesStatusType.Delivered}`}
-								label={SalesStatusType.Delivered}
+								name={`status${SalesStatus.Delivered}`}
+								label={SalesStatus.Delivered}
 								control={control}
 							/>
 						</>

--- a/apps/web/src/hooks/user/useOrderFiltering.tsx
+++ b/apps/web/src/hooks/user/useOrderFiltering.tsx
@@ -1,9 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-	DeliveryMethod,
-	type Order,
-	SalesStatus,
-} from "~/types";
+import { DeliveryMethod, type Order, SalesStatus } from "~/types";
 
 interface UseOrderFilteringProps {
 	orders: Order[];

--- a/apps/web/src/hooks/user/useOrderFiltering.tsx
+++ b/apps/web/src/hooks/user/useOrderFiltering.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import {
+	DeliveryMethod,
+	type Order,
+	SalesStatus,
+} from "~/types";
+
+interface UseOrderFilteringProps {
+	orders: Order[];
+	searchKey: "sellerName" | "buyerName";
+	filters: Record<string, boolean>;
+}
+
+export function useOrderFiltering({
+	orders,
+	searchKey,
+	filters,
+}: UseOrderFilteringProps) {
+	const [searchTerm, setSearchTerm] = useState("");
+	const [isFiltersModalOpen, setIsFiltersModalOpen] = useState(false);
+	const [filteredOrders, setFilteredOrders] = useState(orders);
+	const [activeFilters, setActiveFilters] =
+		useState<Record<string, boolean>>(filters);
+
+	const openFiltersModal = () => setIsFiltersModalOpen(true);
+	const closeFiltersModal = () => setIsFiltersModalOpen(false);
+
+	const applyFilters = (newFilters: Record<string, boolean>) => {
+		setActiveFilters(newFilters);
+		closeFiltersModal();
+	};
+
+	useEffect(() => {
+		const newFilteredOrders = orders
+			.map((orderGroup) => ({
+				...orderGroup,
+				items: orderGroup.items.filter((item) => {
+					const matchesSearch = searchTerm
+						? item[searchKey]?.toLowerCase().includes(searchTerm.toLowerCase())
+						: true;
+
+					const activeStatusFilters = [
+						activeFilters.statusPaid,
+						activeFilters.statusPrepared,
+						activeFilters.statusShipped,
+						activeFilters.statusDelivered,
+					];
+
+					const matchesStatus = activeStatusFilters.some(Boolean)
+						? [
+								{
+									filter: activeFilters.statusPaid,
+									status: SalesStatus.Paid,
+								},
+								{
+									filter: activeFilters.statusPrepared,
+									status: SalesStatus.Prepared,
+								},
+								{
+									filter: activeFilters.statusShipped,
+									status: SalesStatus.Shipped,
+								},
+								{
+									filter: activeFilters.statusDelivered,
+									status: SalesStatus.Delivered,
+								},
+							].some(({ filter, status }) => filter && item.status === status)
+						: true;
+
+					const activeDeliveryFilters = [
+						activeFilters.deliveryAddress,
+						activeFilters.deliveryMeetup,
+					];
+
+					const matchesDelivery = activeDeliveryFilters.some(Boolean)
+						? [
+								{
+									filter: activeFilters.deliveryAddress,
+									deliveryMethod: DeliveryMethod.Address,
+								},
+								{
+									filter: activeFilters.deliveryMeetup,
+									deliveryMethod: DeliveryMethod.Meetup,
+								},
+							].some(
+								({ filter, deliveryMethod }) =>
+									filter && item.delivery === deliveryMethod,
+							)
+						: true;
+
+					return matchesSearch && matchesStatus && matchesDelivery;
+				}),
+			}))
+			.filter((orderGroup) => orderGroup.items.length > 0);
+		if (!searchTerm && !Object.values(activeFilters).some(Boolean)) {
+			setFilteredOrders(orders);
+		} else {
+			setFilteredOrders(newFilteredOrders);
+		}
+	}, [orders, searchKey, searchTerm, activeFilters]);
+
+	return {
+		searchTerm,
+		setSearchTerm,
+		isFiltersModalOpen,
+		openFiltersModal,
+		closeFiltersModal,
+		activeFilters,
+		filteredOrders,
+		applyFilters,
+	};
+}

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -35,7 +35,7 @@ export type SaleDetailsType = {
 	address?: string;
 };
 
-export enum SalesStatusType {
+export enum SalesStatus {
 	Paid = "Paid",
 	Prepared = "Prepared",
 	Shipped = "Shipped",
@@ -68,3 +68,18 @@ export const filtersSchema = z.object({
 });
 
 export type FormValues = z.infer<typeof filtersSchema>;
+
+export interface OrderItem {
+	id: string;
+	productName: string;
+	status: SalesStatus;
+	sellerName?: string;
+	buyerName?: string;
+	delivery?: DeliveryMethod;
+}
+
+export interface Order {
+	date: string;
+	items: OrderItem[];
+}
+

--- a/apps/web/src/types/index.ts
+++ b/apps/web/src/types/index.ts
@@ -82,4 +82,3 @@ export interface Order {
 	date: string;
 	items: OrderItem[];
 }
-


### PR DESCRIPTION
## Description

Closes #57  

1. **Created a custom hook (`useOrderFiltering`):**
   - All logic related to filtering, searching, and state management for orders has been extracted and consolidated into a reusable custom hook. 
   - This reduces duplication and improves code maintainability.

2. **Centralized types into a single file:**
   - A dedicated file was created to centralize `interfaces`, `enums`, and `types` related to orders.
   - This ensures consistency across the codebase and avoids duplicated logic in different files.

3. **Fixed filtering logic (`useEffect`):**
   - The filtering logic was updated because the `??` operator did not correctly evaluate `false` boolean states.
   - Now, all filters (statuses and delivery methods) are properly considered.

## Checklist

- [X] The title of the PR is clear and descriptive.
- [X] All tests have been run and passed.
- [X] Code follows project conventions (Biome formatting, linting).
- [X] Documentation has been updated as needed.
- [X] Commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style.

## Type of Change

- [ ] Bugfix
- [ ] Feature
- [X] Refactor
- [ ] Chore
- [ ] Documentation
- [ ] Test

## Additional Notes

https://www.loom.com/share/b23e6fc857e6494e81fe69723e1687e5?sid=4cbcf37c-214d-48ba-88bb-5a36b974136c

Thank you for the opportunity to contribute to this project.
